### PR TITLE
Fixed error #133

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -16,7 +16,7 @@ from models.networks import get_generator
 class Predictor:
     def __init__(self, weights_path: str, model_name: str = ''):
         with open('config/config.yaml') as cfg:
-            config = yaml.load(cfg)
+            config = yaml.load(cfg, Loader=yaml.FullLoader)
         model = get_generator(model_name or config['model'])
         model.load_state_dict(torch.load(weights_path)['model'])
         self.model = model.cuda()


### PR DESCRIPTION
Referencing error #133 
fixed error "TypeError: load() missing 1 required positional argument: 'Loader'"
This error arose because pyyaml>=5.1 requires a Loader argument. 
Earlier it used to work fine.

